### PR TITLE
Fixed CI to use new API of renode-linux-runner-action

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -58,3 +58,4 @@ jobs:
           renode-run: |
             pip install ./pyrav4l2
             for script in ./examples/*.py; do python $script; done
+          devices: vivid


### PR DESCRIPTION
-Fixed CI to use new API of `renode-linux-runner-action`. In new version `vivid` module is not available by default.