### PR TITLE
frame interval fix and suggested extended method api

### DIFF
--- a/pyrav4l2/device.py
+++ b/pyrav4l2/device.py
@@ -65,12 +65,6 @@ class FrameInterval:
         else:
             return 0.0
 
-    def to_frame_rate(self) -> float:
-        if self.numerator != 0:
-            return self.denominator / self.numerator
-        else:
-            return 0.0
-
 
 class Device:
     """Class representing a v4l2 device"""

--- a/pyrav4l2/device.py
+++ b/pyrav4l2/device.py
@@ -50,14 +50,26 @@ class FrameInterval:
         self.numerator = numerator
         self.denominator = denominator
 
+    def __eq__(self, other: FrameInterval) -> bool:
+        return self.numerator == other.numerator and self.denominator == other.denominator
+
     def __str__(self) -> str:
-        if self.numerator != 0:
-            return str(self.denominator / self.numerator)
+        if self.denominator != 0:
+            return str(self.numerator / self.denominator)
         else:
             return "0.0"
 
-    def __eq__(self, other: FrameInterval) -> bool:
-        return self.numerator == other.numerator and self.denominator == other.denominator
+    def as_float(self) -> float:
+        if self.denominator != 0:
+            return self.numerator / self.denominator
+        else:
+            return 0.0
+
+    def to_frame_rate(self) -> float:
+        if self.numerator != 0:
+            return self.denominator / self.numerator
+        else:
+            return 0.0
 
 
 class Device:

--- a/pyrav4l2/device.py
+++ b/pyrav4l2/device.py
@@ -59,7 +59,7 @@ class FrameInterval:
         else:
             return "0.0"
 
-    def as_float(self) -> float:
+    def __float__(self) -> float:
         if self.denominator != 0:
             return self.numerator / self.denominator
         else:


### PR DESCRIPTION
This is a suggested fix to the suspected https://github.com/antmicro/pyrav4l2/issues/8, while also exemplifying an API enhancement to the same "data" class holding the frame interval value.

I'm not sure however, how would the contained API enhancement for the same class play out with regard to the `V4L2_FRMIVAL_TYPE_CONTINUOUS` and `V4L2_FRMIVAL_TYPE_STEPWISE` options of the v4l2 protocol relevant to [`get_available_frame_intervals`](https://github.com/antmicro/pyrav4l2/blob/ee5332d9868198ad9c825d8ad853d02ec38b6dd8/pyrav4l2/device.py#L416), which at present pyrav4l2 does not seem to handle at all. Not even aware how does a continuous frame interval behave differently than the plain type which is already handled, if it is at all used by many hardware vendors who bake v4l2 compliance into their cameras. At present the code will just yield nothing for those pair of options.

Is there any device driver or library mocking v4l2 compliant camera devices? How would you test any of this?

I wonder, is replicating a useful and mostly sufficient subset of v4l2-ctl in packaged python code making the same IOCTL calls as the original ― which as I understand is what pyrav4l2 is/does ― is it really more economical than wrapping the C++ v4l2 classes and types for direct use in python user code? or does pyrav4l2 aim to provide a _simpler api_ for workflows against v4l2 compliant camera devices?

Thanks again for pyrav4l2.